### PR TITLE
Return all the messages loaded in the Translator

### DIFF
--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -710,6 +710,25 @@ class Translator implements TranslatorInterface
     }
 
     /**
+     * Return all the messages.
+     *
+     * @param string $textDomain
+     * @param null   $locale
+     *
+     * @return mixed
+     */
+    public function getAllMessages($textDomain = 'default', $locale = null)
+    {
+        $locale = $locale ?: $this->getLocale();
+
+        if (!isset($this->messages[$textDomain][$locale])) {
+            $this->loadMessages($textDomain, $locale);
+        }
+
+        return $this->messages[$textDomain][$locale];
+    }
+
+    /**
      * Get the event manager.
      *
      * @return EventManagerInterface|null

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -386,4 +386,48 @@ class TranslatorTest extends TestCase
         $this->assertNull($doNotTrigger);
         $this->assertEquals('BOOYAH', $result);
     }
+
+    public function testGetAllMessagesLoadedInTranslator()
+    {
+        $this->translator->setLocale('en_EN');
+        $this->translator->addTranslationFile(
+            'phparray',
+            $this->testFilesDir . '/translation_en.php',
+            'default',
+            'en_EN'
+        );
+
+        $allMessages = $this->translator->getAllMessages();
+        $this->assertInstanceOf('\Zend\I18n\Translator\TextDomain', $allMessages);
+        $this->assertEquals(7, count($allMessages));
+        $this->assertEquals('Message 1 (en)', $allMessages['Message 1']);
+    }
+
+    public function testGetAllMessagesReturnsNullWhenGivenTextDomainIsNotFound()
+    {
+        $this->translator->setLocale('en_EN');
+        $this->translator->addTranslationFile(
+            'phparray',
+            $this->testFilesDir . '/translation_en.php',
+            'default',
+            'en_EN'
+        );
+
+        $allMessages = $this->translator->getAllMessages('foo_domain');
+        $this->assertNull($allMessages);
+    }
+
+    public function testGetAllMessagesReturnsNullWhenGivenLocaleNotExist()
+    {
+        $this->translator->setLocale('en_EN');
+        $this->translator->addTranslationFile(
+            'phparray',
+            $this->testFilesDir . '/translation_en.php',
+            'default',
+            'en_EN'
+        );
+
+        $allMessages = $this->translator->getAllMessages('default', 'es_ES');
+        $this->assertNull($allMessages);
+    }
 }


### PR DESCRIPTION
Added public method to the I18n\Translator that return all the messages loaded in the Translator: useful in case we want to manage all of them with some tools (refactoring, find&replace, po2json).
