### PR TITLE
[WIP] Refactor with new service manager and event manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     "require-dev": {
         "zendframework/zend-cache": "~2.5",
         "zendframework/zend-config": "~2.5",
-        "zendframework/zend-eventmanager": "~2.5",
+        "zendframework/zend-eventmanager": "dev-develop as 2.7.0",
         "zendframework/zend-filter": "~2.5",
-        "zendframework/zend-servicemanager": "~2.5",
+        "zendframework/zend-servicemanager": "dev-develop as 2.7.0",
         "zendframework/zend-validator": "~2.5",
-        "zendframework/zend-view": "~2.5",
+        "zendframework/zend-view": "dev-develop as 2.6.0",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/src/Translator/LoaderPluginManager.php
+++ b/src/Translator/LoaderPluginManager.php
@@ -11,6 +11,7 @@ namespace Zend\I18n\Translator;
 
 use Zend\I18n\Exception;
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Factory\InvokableFactory;
 
 /**
  * Plugin manager implementation for translation loaders.
@@ -54,15 +55,16 @@ use Zend\ServiceManager\AbstractPluginManager;
  */
 class LoaderPluginManager extends AbstractPluginManager
 {
-    /**
-     * Default set of loaders.
-     *
-     * @var array
-     */
-    protected $invokableClasses = [
-        'gettext'  => 'Zend\I18n\Translator\Loader\Gettext',
-        'ini'      => 'Zend\I18n\Translator\Loader\Ini',
-        'phparray' => 'Zend\I18n\Translator\Loader\PhpArray',
+    protected $aliases = [
+        'gettext'  => Loader\Gettext::class,
+        'ini'      => Loader\Ini::class,
+        'phparray' => Loader\PhpArray::class
+    ];
+
+    protected $factories = [
+        Loader\Gettext::class  => InvokableFactory::class,
+        Loader\Ini::class      => InvokableFactory::class,
+        Loader\PhpArray::class => InvokableFactory::class
     ];
 
     /**

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -19,6 +19,7 @@ use Zend\I18n\Exception;
 use Zend\I18n\Translator\Loader\FileLoaderInterface;
 use Zend\I18n\Translator\Loader\RemoteLoaderInterface;
 use Zend\Stdlib\ArrayUtils;
+use Zend\ServiceManager\ServiceManager;
 
 /**
  * Translator.
@@ -334,7 +335,7 @@ class Translator implements TranslatorInterface
     public function getPluginManager()
     {
         if (!$this->pluginManager instanceof LoaderPluginManager) {
-            $this->setPluginManager(new LoaderPluginManager());
+            $this->setPluginManager(new LoaderPluginManager(new ServiceManager));
         }
 
         return $this->pluginManager;

--- a/src/Translator/TranslatorServiceFactory.php
+++ b/src/Translator/TranslatorServiceFactory.php
@@ -9,14 +9,15 @@
 
 namespace Zend\I18n\Translator;
 
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\Factory\FactoryInterface;
+use Interop\Container\ContainerInterface;
 
 /**
  * Translator.
  */
 class TranslatorServiceFactory implements FactoryInterface
 {
+    /*
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         // Configure the translator
@@ -25,4 +26,15 @@ class TranslatorServiceFactory implements FactoryInterface
         $translator = Translator::factory($trConfig);
         return $translator;
     }
+    */
+
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        // Configure the translator
+        $config = $container->get('Config');
+        $trConfig = isset($config['translator']) ? $config['translator'] : [];
+        $translator = Translator::factory($trConfig);
+        return $translator;
+    }
+
 }

--- a/src/View/HelperConfig.php
+++ b/src/View/HelperConfig.php
@@ -36,12 +36,12 @@ class HelperConfig implements ConfigInterface
      * in this class.
      *
      * @param  ServiceManager $serviceManager
-     * @return void
+     * @return ServiceManager
      */
     public function configureServiceManager(ServiceManager $serviceManager)
     {
-        foreach ($this->invokables as $name => $service) {
-            $serviceManager->setInvokableClass($name, $service);
-        }
+        return $serviceManager->withConfig(
+            [ 'invokables' => $this->invokables ]
+        );
     }
 }

--- a/test/Translator/TranslatorServiceFactoryTest.php
+++ b/test/Translator/TranslatorServiceFactoryTest.php
@@ -23,7 +23,7 @@ class TranslatorServiceFactoryTest extends TestCase
                        ->will($this->returnValueMap($slContents));
 
         $factory = new TranslatorServiceFactory();
-        $translator = $factory->createService($serviceLocator);
+        $translator = $factory($serviceLocator, 'Zend\I18n\Translator\Translator');
         $this->assertInstanceOf('Zend\I18n\Translator\Translator', $translator);
     }
 }

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -165,7 +165,14 @@ class TranslatorTest extends TestCase
     {
         $loader = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
-        $this->translator->getPluginManager()->setService('test', $loader);
+        $pm = $this->translator->getPluginManager();
+        $this->translator->setPluginManager(
+            $pm->withConfig([
+                'services' => [
+                    'test' => $loader
+                ]
+            ])
+        );
         $this->translator->addTranslationFile('test', null);
 
         $this->assertEquals('bar', $this->translator->translate('foo'));


### PR DESCRIPTION
This PR contains the refactor of zend-i18n with the new [zend-servicemanager](https://github.com/zendframework/zend-servicemanager/tree/develop) and [zend-eventmanager](https://github.com/zendframework/zend-eventmanager/tree/develop) of ZF3.

**Note:** this PR is a work in progress, don't merge it!

To do:
- [ ] wait for the refactor of [zend-cache](https://github.com/zendframework/zend-cache) with the new service and event manager (this is used by zend-i18n);
- [ ] fix the unit tests;
