### PR TITLE
Update PostCode.php

### DIFF
--- a/src/Validator/PostCode.php
+++ b/src/Validator/PostCode.php
@@ -178,7 +178,7 @@ class PostCode extends AbstractValidator
         'AS' => '96799',
         'CC' => '6799',
         'CK' => '\d{4}',
-        'RS' => '\d{6}',
+        'RS' => '\d{5}',
         'ME' => '8\d{4}',
         'CS' => '\d{5}',
         'YU' => '\d{5}',


### PR DESCRIPTION
Post code in Serbia (RS) consists of five digits. #7 
