### PR TITLE
Multiple isValid calls

### DIFF
--- a/src/Validator/DateTime.php
+++ b/src/Validator/DateTime.php
@@ -275,16 +275,17 @@ class DateTime extends AbstractValidator
             throw new ValidatorException\InvalidArgumentException($intlException->getMessage(), 0, $intlException);
         }
 
-
         try {
             $timestamp = $formatter->parse($value);
 
             if (intl_is_failure($formatter->getErrorCode()) || $timestamp === false) {
                 $this->error(self::INVALID_DATETIME);
+                $this->invalidateFormatter = true;
                 return false;
             }
         } catch (IntlException $intlException) {
             $this->error(self::INVALID_DATETIME);
+            $this->invalidateFormatter = true;
             return false;
         }
 
@@ -305,10 +306,12 @@ class DateTime extends AbstractValidator
                 $this->getTimeType(),
                 $this->getTimezone(),
                 $this->getCalendar(),
-                $this->getPattern()
+                $this->pattern
             );
 
             $this->formatter->setLenient(false);
+
+            $this->setPattern($this->formatter->getPattern());
 
             $this->invalidateFormatter = false;
         }

--- a/src/Validator/DateTime.php
+++ b/src/Validator/DateTime.php
@@ -304,13 +304,15 @@ class DateTime extends AbstractValidator
                 $this->getLocale(),
                 $this->getDateType(),
                 $this->getTimeType(),
-                $this->getTimezone(),
-                $this->getCalendar(),
+                $this->timezone,
+                $this->calendar,
                 $this->pattern
             );
 
             $this->formatter->setLenient(false);
 
+            $this->setTimezone($this->formatter->getTimezone());
+            $this->setCalendar($this->formatter->getCalendar());
             $this->setPattern($this->formatter->getPattern());
 
             $this->invalidateFormatter = false;

--- a/test/Validator/DateTimeTest.php
+++ b/test/Validator/DateTimeTest.php
@@ -201,4 +201,18 @@ class DateTimeTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->validator->isValid('02:00'));
         $this->assertEquals('hh:mm', $this->validator->getPattern());
     }
+
+    public function testMultipleIsValidCalls()
+    {
+        $this->validator
+            ->setLocale('pt_BR')
+            ->setDateType(IntlDateFormatter::MEDIUM)
+            ->setTimeType(IntlDateFormatter::MEDIUM);
+
+        $this->assertTrue($this->validator->isValid('31/12/2015 23:59:59'));
+        $this->assertFalse($this->validator->isValid('31/12/2015'));
+        $this->assertFalse($this->validator->isValid('23:59:59'));
+        $this->assertFalse($this->validator->isValid('does not matter'));
+        $this->assertTrue($this->validator->isValid('31/12/2015 23:59:59'));
+    }
 }


### PR DESCRIPTION
When we call validator with a forced parse error, next time we try to validate, we'll always receive `false`. I just fixed it, cleaning the `$this->formatter` and reconfiguring it directly with configured object parameters.

Please check `ZendTest\Validator\DateTimeTest::testMultipleIsValidCalls` test.
