### PR TITLE
Support zend-servicemanager v2+v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,24 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - SERVICE_MANAGER_V2=true
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - SERVICE_MANAGER_V2=true
     - php: 7
+    - php: 7
+      env:
+        - SERVICE_MANAGER_V2=true
     - php: hhvm 
+    - php: hhvm 
+      env:
+        - SERVICE_MANAGER_V2=true
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:
@@ -34,6 +45,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^2.7.2" ; fi
+  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,24 +19,24 @@ matrix:
         - EXECUTE_CS_CHECK=true
     - php: 5.5
       env:
-        - SERVICE_MANAGER_VERSION="^2.7.3"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
         - EVENT_MANAGER_VERSION="^2.6.2"
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
     - php: 5.6
       env:
-        - SERVICE_MANAGER_VERSION="^2.7.3"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
         - EVENT_MANAGER_VERSION="^2.6.2"
     - php: 7
     - php: 7
       env:
-        - SERVICE_MANAGER_VERSION="^2.7.3"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
         - EVENT_MANAGER_VERSION="^2.6.2"
     - php: hhvm 
     - php: hhvm 
       env:
-        - SERVICE_MANAGER_VERSION="^2.7.3"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
         - EVENT_MANAGER_VERSION="^2.6.2"
   allow_failures:
     - php: hhvm
@@ -50,7 +50,8 @@ before_install:
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
-  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-cache zendframework/zend-validator zendframework/zend-view ; fi
   - if [[ $EVENT_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION" ; fi
   - if [[ $EVENT_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^3.0" ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,21 +19,25 @@ matrix:
         - EXECUTE_CS_CHECK=true
     - php: 5.5
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION="^2.7.3"
+        - EVENT_MANAGER_VERSION="^2.6.2"
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
     - php: 5.6
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION="^2.7.3"
+        - EVENT_MANAGER_VERSION="^2.6.2"
     - php: 7
     - php: 7
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION="^2.7.3"
+        - EVENT_MANAGER_VERSION="^2.6.2"
     - php: hhvm 
     - php: hhvm 
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION="^2.7.3"
+        - EVENT_MANAGER_VERSION="^2.6.2"
   allow_failures:
     - php: hhvm
 
@@ -45,8 +49,10 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
-  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^2.7.2" ; fi
-  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
+  - if [[ $EVENT_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION" ; fi
+  - if [[ $EVENT_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^3.0" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-stdlib": "^2.5"
     },
     "require-dev": {
         "zendframework/zend-cache": "dev-develop as 2.6.0",
         "zendframework/zend-config": "~2.5",
         "zendframework/zend-eventmanager": "dev-develop as 2.7.0",
         "zendframework/zend-filter": "~2.5",
-        "zendframework/zend-servicemanager": "dev-develop as 2.7.0",
+        "zendframework/zend-servicemanager": "^2.7.2 || ^3.0",
         "zendframework/zend-validator": "~2.5",
         "zendframework/zend-view": "dev-develop as 2.6.0",
         "fabpot/php-cs-fixer": "1.7.*",
@@ -43,7 +43,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.5-dev",
-            "dev-develop": "3.0-dev"
+            "dev-develop": "2.6-dev"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -7,23 +7,24 @@
         "i18n"
     ],
     "homepage": "https://github.com/zendframework/zend-i18n",
-    "autoload": {
-        "psr-4": {
-            "Zend\\I18n\\": "src/"
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.5-dev",
+            "dev-develop": "2.6-dev"
         }
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "zendframework/zend-stdlib": "^2.5"
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-cache": "dev-develop as 2.6.0",
-        "zendframework/zend-config": "~2.5",
+        "zendframework/zend-cache": "^2.5",
+        "zendframework/zend-config": "^2.6",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
-        "zendframework/zend-filter": "~2.5",
-        "zendframework/zend-servicemanager": "^2.7.3 || ^3.0",
-        "zendframework/zend-validator": "~2.5",
-        "zendframework/zend-view": "dev-develop as 2.6.0",
+        "zendframework/zend-filter": "^2.6.1",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+        "zendframework/zend-validator": "^2.5",
+        "zendframework/zend-view": "^2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },
@@ -38,12 +39,9 @@
         "zendframework/zend-view": "You should install this package to use the provided view helpers",
         "zendframework/zend-i18n-resources": "Translation resources"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.5-dev",
-            "dev-develop": "2.6-dev"
+    "autoload": {
+        "psr-4": {
+            "Zend\\I18n\\": "src/"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "zendframework/zend-config": "~2.5",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
         "zendframework/zend-filter": "~2.5",
-        "zendframework/zend-servicemanager": "^2.7.2 || ^3.0",
+        "zendframework/zend-servicemanager": "^2.7.3 || ^3.0",
         "zendframework/zend-validator": "~2.5",
         "zendframework/zend-view": "dev-develop as 2.6.0",
         "fabpot/php-cs-fixer": "1.7.*",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "zendframework/zend-cache": "dev-develop as 2.6.0",
         "zendframework/zend-config": "~2.5",
-        "zendframework/zend-eventmanager": "dev-develop as 2.7.0",
+        "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
         "zendframework/zend-filter": "~2.5",
         "zendframework/zend-servicemanager": "^2.7.2 || ^3.0",
         "zendframework/zend-validator": "~2.5",

--- a/src/Translator/LoaderPluginManager.php
+++ b/src/Translator/LoaderPluginManager.php
@@ -90,4 +90,17 @@ class LoaderPluginManager extends AbstractPluginManager
             __NAMESPACE__
         ));
     }
+
+    /**
+     * Validate the plugin is of the expected type (v2).
+     *
+     * Proxies to `validate()`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validatePlugin($instance)
+    {
+        $this->validate($instance);
+    }
 }

--- a/src/Translator/LoaderPluginManager.php
+++ b/src/Translator/LoaderPluginManager.php
@@ -77,7 +77,7 @@ class LoaderPluginManager extends AbstractPluginManager
      * @return void
      * @throws Exception\RuntimeException if invalid
      */
-    public function validatePlugin($plugin)
+    public function validate($plugin)
     {
         if ($plugin instanceof Loader\FileLoaderInterface || $plugin instanceof Loader\RemoteLoaderInterface) {
             // we're okay

--- a/src/Translator/LoaderPluginManager.php
+++ b/src/Translator/LoaderPluginManager.php
@@ -104,17 +104,18 @@ class LoaderPluginManager extends AbstractPluginManager
      *
      * Proxies to `validate()`.
      *
-     * @param mixed $instance
+     * @param mixed $plugin
      * @throws Exception\RuntimeException
      */
-    public function validatePlugin($instance)
+    public function validatePlugin($plugin)
     {
         try {
-            $this->validate($instance);
+            $this->validate($plugin);
         } catch (InvalidServiceException $e) {
             throw new Exception\RuntimeException(sprintf(
                 'Plugin of type %s is invalid; must implement %s\Loader\FileLoaderInterface or %s\Loader\RemoteLoaderInterface',
                 (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+                __NAMESPACE__,
                 __NAMESPACE__
             ));
         }

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -13,6 +13,7 @@ use Locale;
 use Traversable;
 use Zend\Cache;
 use Zend\Cache\Storage\StorageInterface as CacheStorage;
+use Zend\EventManager\Event;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerInterface;
 use Zend\I18n\Exception;
@@ -449,16 +450,15 @@ class Translator implements TranslatorInterface
             $until = function ($r) {
                 return is_string($r);
             };
-            $results = $this->getEventManager()->triggerUntil(
-                $until,
-                self::EVENT_MISSING_TRANSLATION,
-                $this,
-                [
-                    'message'     => $message,
-                    'locale'      => $locale,
-                    'text_domain' => $textDomain,
-                ]
-            );
+
+            $event = new Event(self::EVENT_MISSING_TRANSLATION, $this, [
+                'message'     => $message,
+                'locale'      => $locale,
+                'text_domain' => $textDomain,
+            ]);
+
+            $results = $this->getEventManager()->triggerEventUntil($until, $event);
+
             $last = $results->last();
             if (is_string($last)) {
                 return $last;
@@ -579,15 +579,14 @@ class Translator implements TranslatorInterface
                 $until = function ($r) {
                     return ($r instanceof TextDomain);
                 };
-                $results = $this->getEventManager()->triggerUntil(
-                    $until,
-                    self::EVENT_NO_MESSAGES_LOADED,
-                    $this,
-                    [
-                        'locale'      => $locale,
-                        'text_domain' => $textDomain,
-                    ]
-                );
+
+                $event = new Event(self::EVENT_NO_MESSAGES_LOADED, $this, [
+                    'locale'      => $locale,
+                    'text_domain' => $textDomain,
+                ]);
+
+                $results = $this->getEventManager()->triggerEventUntil($until, $event);
+
                 $last = $results->last();
                 if ($last instanceof TextDomain) {
                     $discoveredTextDomain = $last;

--- a/src/Translator/TranslatorServiceFactory.php
+++ b/src/Translator/TranslatorServiceFactory.php
@@ -9,25 +9,23 @@
 
 namespace Zend\I18n\Translator;
 
-use Zend\ServiceManager\Factory\FactoryInterface;
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Translator.
  */
 class TranslatorServiceFactory implements FactoryInterface
 {
-    /*
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        // Configure the translator
-        $config = $serviceLocator->get('Config');
-        $trConfig = isset($config['translator']) ? $config['translator'] : [];
-        $translator = Translator::factory($trConfig);
-        return $translator;
-    }
-    */
-
+    /**
+     * Create a Translator instance.
+     *
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     * @return Translator
+     */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         // Configure the translator
@@ -35,5 +33,18 @@ class TranslatorServiceFactory implements FactoryInterface
         $trConfig = isset($config['translator']) ? $config['translator'] : [];
         $translator = Translator::factory($trConfig);
         return $translator;
+    }
+
+    /**
+     * zend-servicemanager v2 factory for creating Translator instance.
+     *
+     * Proxies to `__invoke()`.
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @returns Translator
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, Translator::class);
     }
 }

--- a/src/Translator/TranslatorServiceFactory.php
+++ b/src/Translator/TranslatorServiceFactory.php
@@ -29,7 +29,7 @@ class TranslatorServiceFactory implements FactoryInterface
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         // Configure the translator
-        $config = $container->get('Config');
+        $config = $container->get('config');
         $trConfig = isset($config['translator']) ? $config['translator'] : [];
         $translator = Translator::factory($trConfig);
         return $translator;

--- a/src/View/HelperConfig.php
+++ b/src/View/HelperConfig.php
@@ -52,6 +52,15 @@ class HelperConfig implements ConfigInterface
         Helper\Plural::class => InvokableFactory::class,
         Helper\Translate::class => InvokableFactory::class,
         Helper\TranslatePlural::class => InvokableFactory::class,
+        // Legacy (v2) due to alias resolution; canonical form of resolved
+        // alias is used to look up the factory, while the non-normalized
+        // resolved alias is used as the requested name passed to the factory.
+        'zendi18nviewhelpercurrencyformat' => InvokableFactory::class,
+        'zendi18nviewhelperdateformat' => InvokableFactory::class,
+        'zendi18nviewhelpernumberformat' => InvokableFactory::class,
+        'zendi18nviewhelperplural' => InvokableFactory::class,
+        'zendi18nviewhelpertranslate' => InvokableFactory::class,
+        'zendi18nviewhelpertranslateplural' => InvokableFactory::class,
     ];
 
     /**

--- a/src/View/HelperConfig.php
+++ b/src/View/HelperConfig.php
@@ -10,6 +10,7 @@
 namespace Zend\I18n\View;
 
 use Zend\ServiceManager\ConfigInterface;
+use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\ServiceManager\ServiceManager;
 
 /**
@@ -18,17 +19,39 @@ use Zend\ServiceManager\ServiceManager;
 class HelperConfig implements ConfigInterface
 {
     /**
-     * Pre-aliased view helpers
-     *
+     * Common aliases for helpers
      * @var array
      */
-    protected $invokables = [
-        'currencyformat'  => 'Zend\I18n\View\Helper\CurrencyFormat',
-        'dateformat'      => 'Zend\I18n\View\Helper\DateFormat',
-        'numberformat'    => 'Zend\I18n\View\Helper\NumberFormat',
-        'plural'          => 'Zend\I18n\View\Helper\Plural',
-        'translate'       => 'Zend\I18n\View\Helper\Translate',
-        'translateplural' => 'Zend\I18n\View\Helper\TranslatePlural',
+    protected $aliases = [
+        'currencyformat' => Helper\CurrencyFormat::class,
+        'currencyFormat' => Helper\CurrencyFormat::class,
+        'CurrencyFormat' => Helper\CurrencyFormat::class,
+        'dateformat' => Helper\DateFormat::class,
+        'dateFormat' => Helper\DateFormat::class,
+        'DateFormat' => Helper\DateFormat::class,
+        'numberformat' => Helper\NumberFormat::class,
+        'numberFormat' => Helper\NumberFormat::class,
+        'NumberFormat' => Helper\NumberFormat::class,
+        'plural' => Helper\Plural::class,
+        'Plural' => Helper\Plural::class,
+        'translate' => Helper\Translate::class,
+        'Translate' => Helper\Translate::class,
+        'translateplural' => Helper\TranslatePlural::class,
+        'translatePlural' => Helper\TranslatePlural::class,
+        'TranslatePlural' => Helper\TranslatePlural::class,
+    ];
+
+    /**
+     * Factories for included helpers.
+     * @var array
+     */
+    protected $factories = [
+        Helper\CurrencyFormat::class => InvokableFactory::class,
+        Helper\DateFormat::class => InvokableFactory::class,
+        Helper\NumberFormat::class => InvokableFactory::class,
+        Helper\Plural::class => InvokableFactory::class,
+        Helper\Translate::class => InvokableFactory::class,
+        Helper\TranslatePlural::class => InvokableFactory::class,
     ];
 
     /**
@@ -40,8 +63,27 @@ class HelperConfig implements ConfigInterface
      */
     public function configureServiceManager(ServiceManager $serviceManager)
     {
-        return $serviceManager->withConfig(
-            [ 'invokables' => $this->invokables ]
-        );
+        foreach ($this->factories as $name => $factory) {
+            $serviceManager->setFactory($name, $factory);
+        }
+        foreach ($this->aliases as $alias => $target) {
+            $serviceManager->setAlias($alias, $target);
+        }
+        return $serviceManager;
+    }
+
+    /**
+     * Cast configuration to an array.
+     *
+     * Provided for v3 compatibility
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'aliases' => $this->aliases,
+            'factories' => $this->factories,
+        ];
     }
 }

--- a/test/Translator/LoaderPluginManagerCompatibilityTest.php
+++ b/test/Translator/LoaderPluginManagerCompatibilityTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\I18n\Translator;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use ReflectionProperty;
 use Zend\I18n\Exception\RuntimeException;
 use Zend\I18n\Translator\LoaderPluginManager;
 use Zend\ServiceManager\ServiceManager;

--- a/test/Translator/LoaderPluginManagerCompatibilityTest.php
+++ b/test/Translator/LoaderPluginManagerCompatibilityTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-i18n for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\I18n\Translator;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
+use Zend\I18n\Exception\RuntimeException;
+use Zend\I18n\Translator\LoaderPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class LoaderPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new LoaderPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return RuntimeException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return Filter\FilterInterface::class;
+    }
+
+    public function testInstanceOfMatches()
+    {
+        $this->markTestSkipped('Test skipped as LoaderPluginManager allows multiple instance types');
+    }
+}

--- a/test/Translator/TranslatorServiceFactoryTest.php
+++ b/test/Translator/TranslatorServiceFactoryTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\I18n\Translator;
 
+use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\I18n\Translator\TranslatorServiceFactory;
 
@@ -16,8 +17,8 @@ class TranslatorServiceFactoryTest extends TestCase
 {
     public function testCreateServiceWithNoTranslatorKeyDefined()
     {
-        $slContents = [['Configuration', []]];
-        $serviceLocator = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $slContents = [['config', []]];
+        $serviceLocator = $this->getMock(ContainerInterface::class);
         $serviceLocator->expects($this->once())
                        ->method('get')
                        ->will($this->returnValueMap($slContents));

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -14,6 +14,7 @@ use Locale;
 use Zend\EventManager\EventInterface;
 use Zend\I18n\Translator\Translator;
 use Zend\I18n\Translator\TextDomain;
+use Zend\ServiceManager\Config;
 use ZendTest\I18n\Translator\TestAsset\Loader as TestLoader;
 
 class TranslatorTest extends TestCase
@@ -165,14 +166,14 @@ class TranslatorTest extends TestCase
     {
         $loader = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
+        $config = new Config([
+            'services' => [
+                'test' => $loader
+            ]
+        ]);
         $pm = $this->translator->getPluginManager();
-        $this->translator->setPluginManager(
-            $pm->configure([
-                'services' => [
-                    'test' => $loader
-                ]
-            ])
-        );
+        $config->configureServiceManager($pm);
+        $this->translator->setPluginManager($pm);
         $this->translator->addTranslationFile('test', null);
 
         $this->assertEquals('bar', $this->translator->translate('foo'));
@@ -198,7 +199,9 @@ class TranslatorTest extends TestCase
 
         $loader = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
-        $plugins = $this->translator->getPluginManager()->configure(['services' => ['test' => $loader]]);
+        $config = new Config(['services' => ['test' => $loader]]);
+        $plugins = $this->translator->getPluginManager();
+        $config->configureServiceManager($plugins);
         $this->translator->setPluginManager($plugins);
         $this->translator->addTranslationFile('test', null);
 

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -133,6 +133,13 @@ class TranslatorTest extends TestCase
 
     public function testFactoryCreatesTranslatorWithCache()
     {
+        if (! interface_exists('Zend\Cache\Storage\StorageInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-cache until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         $translator = Translator::factory([
             'locale' => 'de_DE',
             'patterns' => [
@@ -181,6 +188,13 @@ class TranslatorTest extends TestCase
 
     public function testTranslationsLoadedFromCache()
     {
+        if (! interface_exists('Zend\Cache\Storage\StorageInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-cache until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         $cache = \Zend\Cache\StorageFactory::factory(['adapter' => 'memory']);
         $this->translator->setCache($cache);
 
@@ -194,6 +208,13 @@ class TranslatorTest extends TestCase
 
     public function testTranslationsAreStoredInCache()
     {
+        if (! interface_exists('Zend\Cache\Storage\StorageInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-cache until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         $cache = \Zend\Cache\StorageFactory::factory(['adapter' => 'memory']);
         $this->translator->setCache($cache);
 

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -167,7 +167,7 @@ class TranslatorTest extends TestCase
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
         $pm = $this->translator->getPluginManager();
         $this->translator->setPluginManager(
-            $pm->withConfig([
+            $pm->configure([
                 'services' => [
                     'test' => $loader
                 ]
@@ -198,7 +198,7 @@ class TranslatorTest extends TestCase
 
         $loader = new TestLoader();
         $loader->textDomain = new TextDomain(['foo' => 'bar']);
-        $plugins = $this->translator->getPluginManager()->withConfig(['services' => ['test' => $loader]]);
+        $plugins = $this->translator->getPluginManager()->configure(['services' => ['test' => $loader]]);
         $this->translator->setPluginManager($plugins);
         $this->translator->addTranslationFile('test', null);
 

--- a/test/Validator/AlnumTest.php
+++ b/test/Validator/AlnumTest.php
@@ -28,6 +28,13 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-validator until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
@@ -94,7 +101,7 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
                 $result,
                 $this->validator->isValid($input),
                 "Expected '$input' to be considered " . ($result ? '' : 'in') . "valid"
-                );
+            );
         }
     }
 
@@ -144,7 +151,10 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals($validator->getOption('messageTemplates'),
-                                     'messageTemplates', $validator);
+        $this->assertAttributeEquals(
+            $validator->getOption('messageTemplates'),
+            'messageTemplates',
+            $validator
+        );
     }
 }

--- a/test/Validator/AlphaTest.php
+++ b/test/Validator/AlphaTest.php
@@ -23,6 +23,13 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-validator until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
@@ -105,7 +112,10 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals($validator->getOption('messageTemplates'),
-                                     'messageTemplates', $validator);
+        $this->assertAttributeEquals(
+            $validator->getOption('messageTemplates'),
+            'messageTemplates',
+            $validator
+        );
     }
 }

--- a/test/Validator/DateTimeTest.php
+++ b/test/Validator/DateTimeTest.php
@@ -35,6 +35,13 @@ class DateTimeTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-validator until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/Validator/FloatTest.php
+++ b/test/Validator/FloatTest.php
@@ -29,6 +29,13 @@ class FloatTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-validator until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         if (version_compare(PHP_VERSION, '7.0', '>=')) {
             $this->markTestSkipped('Cannot test Float validator under PHP 7; reserved keyword');
         }

--- a/test/Validator/IntTest.php
+++ b/test/Validator/IntTest.php
@@ -29,6 +29,13 @@ class IntTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-validator until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         if (version_compare(PHP_VERSION, '7.0', '>=')) {
             $this->markTestSkipped('Cannot test Int validator under PHP 7; reserved keyword');
         }

--- a/test/Validator/IsFloatTest.php
+++ b/test/Validator/IsFloatTest.php
@@ -30,6 +30,13 @@ class IsFloatTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-validator until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/Validator/IsIntTest.php
+++ b/test/Validator/IsIntTest.php
@@ -29,6 +29,13 @@ class IsIntTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-validator until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/Validator/PhoneNumberTest.php
+++ b/test/Validator/PhoneNumberTest.php
@@ -3038,6 +3038,13 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-validator until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         $this->validator = new PhoneNumber();
     }
 

--- a/test/Validator/PostCodeTest.php
+++ b/test/Validator/PostCodeTest.php
@@ -28,6 +28,13 @@ class PostCodeTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-validator until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
@@ -199,8 +206,11 @@ class PostCodeTest extends \PHPUnit_Framework_TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals($validator->getOption('messageTemplates'),
-                                     'messageTemplates', $validator);
+        $this->assertAttributeEquals(
+            $validator->getOption('messageTemplates'),
+            'messageTemplates',
+            $validator
+        );
     }
 
     /**

--- a/test/View/Helper/CurrencyFormatTest.php
+++ b/test/View/Helper/CurrencyFormatTest.php
@@ -31,6 +31,13 @@ class CurrencyFormatTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (! interface_exists('Zend\View\Helper\HelperInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-view until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/View/Helper/DateFormatTest.php
+++ b/test/View/Helper/DateFormatTest.php
@@ -35,6 +35,13 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (! interface_exists('Zend\View\Helper\HelperInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-view until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
@@ -213,7 +220,11 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                          ->format($date->getTimestamp());
 
         $this->assertMbStringEquals($expected, $this->helper->__invoke(
-            $date, $dateType, $timeType, $locale, null
+            $date,
+            $dateType,
+            $timeType,
+            $locale,
+            null
         ));
     }
 
@@ -230,7 +241,9 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                          ->format($date->getTimestamp());
 
         $this->assertMbStringEquals($expected, $this->helper->__invoke(
-            $date, $dateType, $timeType
+            $date,
+            $dateType,
+            $timeType
         ));
     }
 
@@ -246,7 +259,11 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                          ->format($date->getTimestamp());
 
         $this->assertMbStringEquals($expected, $this->helper->__invoke(
-            $date, $dateType, $timeType, $locale, $pattern
+            $date,
+            $dateType,
+            $timeType,
+            $locale,
+            $pattern
         ));
     }
 
@@ -272,7 +289,7 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $test, $message);
     }
 
-    public function getIntlDateFormatter($locale, $dateType, $timeType, $timezone, $pattern=null)
+    public function getIntlDateFormatter($locale, $dateType, $timeType, $timezone, $pattern = null)
     {
         return new IntlDateFormatter($locale, $dateType, $timeType, $timezone, null, $pattern);
     }

--- a/test/View/Helper/NumberFormatTest.php
+++ b/test/View/Helper/NumberFormatTest.php
@@ -34,6 +34,13 @@ class NumberFormatTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (! interface_exists('Zend\View\Helper\HelperInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-view until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
@@ -160,7 +167,11 @@ class NumberFormatTest extends \PHPUnit_Framework_TestCase
     public function testBasic($locale, $formatStyle, $formatType, $decimals, $number, $expected)
     {
         $this->assertMbStringEquals($expected, $this->helper->__invoke(
-            $number, $formatStyle, $formatType, $locale, $decimals
+            $number,
+            $formatStyle,
+            $formatType,
+            $locale,
+            $decimals
         ));
     }
 

--- a/test/View/Helper/PluralTest.php
+++ b/test/View/Helper/PluralTest.php
@@ -29,6 +29,13 @@ class PluralTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (! interface_exists('Zend\View\Helper\HelperInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-view until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/View/Helper/TranslatePluralTest.php
+++ b/test/View/Helper/TranslatePluralTest.php
@@ -30,6 +30,13 @@ class TranslatePluralTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (! interface_exists('Zend\View\Helper\HelperInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-view until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         $this->helper = new TranslatePluralHelper();
     }
 
@@ -98,7 +105,11 @@ class TranslatePluralTest extends \PHPUnit_Framework_TestCase
         $this->helper->setTranslator($translatorMock);
 
         $this->assertEquals($expected, $this->helper->__invoke(
-            $singularInput, $pluralInput, $numberInput, $textDomain, $locale
+            $singularInput,
+            $pluralInput,
+            $numberInput,
+            $textDomain,
+            $locale
         ));
     }
 }

--- a/test/View/Helper/TranslateTest.php
+++ b/test/View/Helper/TranslateTest.php
@@ -30,6 +30,13 @@ class TranslateTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (! interface_exists('Zend\View\Helper\HelperInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests that utilize zend-view until that component is '
+                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
+            );
+        }
+
         $this->helper = new TranslateHelper();
     }
 


### PR DESCRIPTION
This patch builds on the one originally submitted via #21, and expands it to provide support for both v2 and v3 of zend-servicemanager. Specifically, it introduces the following changes:
- `composer.json`:
  - Updates PHP version to `^5.5 || ^7.0`
  - Updates develop branch alias to `2.6`
  - Updates zend-servicemanager requirement to `^2.7.2 || ^3.0`
- Code changes:
  - Updated `LoaderPluginManager` to implement both `validate()` and `validatePlugin()` (latter proxies to former).
  - Updated `TranslatorServiceFactory` to implement both v2 and v3 factory methods, with v2 method proxying to v3.
  - Updated `HelperConfig`:
    - define aliases + invokable factories;
  - alter `configureServiceManager` to call SM methods setters instead of `configure()` (for portability)
  - implemented `toArray()` (v3 method)
  - Updated `TranslatorTest` to use Config objects + `configureServiceManager()` method to seed SM and plugin manager instances.
