### PR TITLE
No longer skip validator or cache tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
-  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-cache zendframework/zend-validator zendframework/zend-view ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-view ; fi
   - if [[ $EVENT_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION" ; fi
   - if [[ $EVENT_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^3.0" ; fi
 

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-cache": "^2.5",
+        "zendframework/zend-cache": "^2.6.1",
         "zendframework/zend-config": "^2.6",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
         "zendframework/zend-filter": "^2.6.1",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-        "zendframework/zend-validator": "^2.5",
-        "zendframework/zend-view": "^2.5",
+        "zendframework/zend-validator": "^2.6",
+        "zendframework/zend-view": "^2.5.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -133,13 +133,6 @@ class TranslatorTest extends TestCase
 
     public function testFactoryCreatesTranslatorWithCache()
     {
-        if (! interface_exists('Zend\Cache\Storage\StorageInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-cache until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         $translator = Translator::factory([
             'locale' => 'de_DE',
             'patterns' => [
@@ -188,13 +181,6 @@ class TranslatorTest extends TestCase
 
     public function testTranslationsLoadedFromCache()
     {
-        if (! interface_exists('Zend\Cache\Storage\StorageInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-cache until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         $cache = \Zend\Cache\StorageFactory::factory(['adapter' => 'memory']);
         $this->translator->setCache($cache);
 
@@ -208,13 +194,6 @@ class TranslatorTest extends TestCase
 
     public function testTranslationsAreStoredInCache()
     {
-        if (! interface_exists('Zend\Cache\Storage\StorageInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-cache until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         $cache = \Zend\Cache\StorageFactory::factory(['adapter' => 'memory']);
         $this->translator->setCache($cache);
 

--- a/test/Validator/AlnumTest.php
+++ b/test/Validator/AlnumTest.php
@@ -28,13 +28,6 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-validator until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/Validator/AlphaTest.php
+++ b/test/Validator/AlphaTest.php
@@ -23,13 +23,6 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-validator until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/Validator/DateTimeTest.php
+++ b/test/Validator/DateTimeTest.php
@@ -35,13 +35,6 @@ class DateTimeTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-validator until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/Validator/FloatTest.php
+++ b/test/Validator/FloatTest.php
@@ -29,13 +29,6 @@ class FloatTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-validator until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         if (version_compare(PHP_VERSION, '7.0', '>=')) {
             $this->markTestSkipped('Cannot test Float validator under PHP 7; reserved keyword');
         }

--- a/test/Validator/IntTest.php
+++ b/test/Validator/IntTest.php
@@ -29,13 +29,6 @@ class IntTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-validator until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         if (version_compare(PHP_VERSION, '7.0', '>=')) {
             $this->markTestSkipped('Cannot test Int validator under PHP 7; reserved keyword');
         }

--- a/test/Validator/IsFloatTest.php
+++ b/test/Validator/IsFloatTest.php
@@ -30,13 +30,6 @@ class IsFloatTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-validator until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/Validator/IsIntTest.php
+++ b/test/Validator/IsIntTest.php
@@ -29,13 +29,6 @@ class IsIntTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-validator until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/Validator/PhoneNumberTest.php
+++ b/test/Validator/PhoneNumberTest.php
@@ -3038,13 +3038,6 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-validator until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         $this->validator = new PhoneNumber();
     }
 

--- a/test/Validator/PostCodeTest.php
+++ b/test/Validator/PostCodeTest.php
@@ -28,13 +28,6 @@ class PostCodeTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-validator until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }


### PR DESCRIPTION
This patch updates the component to:
- never omit the zend-cache or zend-validator dependencies during CI builds.
- up the zend-cache and zend-validator dependencies to those known to have forwards compatibility.
- change the zend-view dependency to `^2.5.3`, ensuring it can use the 2.6 series of zend-eventmanager.
