### PR TITLE
Re-enable zend-view tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,6 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
-  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-view ; fi
   - if [[ $EVENT_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION" ; fi
   - if [[ $EVENT_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-eventmanager:^3.0" ; fi
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "zendframework/zend-filter": "^2.6.1",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-validator": "^2.6",
-        "zendframework/zend-view": "^2.5.3",
+        "zendframework/zend-view": "^2.6.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/test/View/Helper/CurrencyFormatTest.php
+++ b/test/View/Helper/CurrencyFormatTest.php
@@ -31,13 +31,6 @@ class CurrencyFormatTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        if (! interface_exists('Zend\View\Helper\HelperInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-view until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/View/Helper/NumberFormatTest.php
+++ b/test/View/Helper/NumberFormatTest.php
@@ -34,13 +34,6 @@ class NumberFormatTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        if (! interface_exists('Zend\View\Helper\HelperInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-view until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/View/Helper/PluralTest.php
+++ b/test/View/Helper/PluralTest.php
@@ -29,13 +29,6 @@ class PluralTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        if (! interface_exists('Zend\View\Helper\HelperInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-view until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }

--- a/test/View/Helper/TranslatePluralTest.php
+++ b/test/View/Helper/TranslatePluralTest.php
@@ -30,13 +30,6 @@ class TranslatePluralTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        if (! interface_exists('Zend\View\Helper\HelperInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-view until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         $this->helper = new TranslatePluralHelper();
     }
 

--- a/test/View/Helper/TranslateTest.php
+++ b/test/View/Helper/TranslateTest.php
@@ -30,13 +30,6 @@ class TranslateTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        if (! interface_exists('Zend\View\Helper\HelperInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests that utilize zend-view until that component is '
-                . 'forwards-compatible with zend-stdlib and zend-servicemanager v3'
-            );
-        }
-
         $this->helper = new TranslateHelper();
     }
 


### PR DESCRIPTION
Now that zend-view has a known-stable, forwards compatible version, we can re-enable tests against it on Travis.
