### PR TITLE
Standalone package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,10 @@
         "branch-alias": {
             "dev-master": "2.6-dev",
             "dev-develop": "2.7-dev"
+        },
+        "zf": {
+            "component": "Zend\\I18n",
+            "config-provider": "Zend\\I18n\\ConfigProvider"
         }
     },
     "require": {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-i18n for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\I18n;
+
+use Zend\ServiceManager\Factory\InvokableFactory;
+
+class ConfigProvider
+{
+    /**
+     * Return general-purpose zend-i18n configuration.
+     *
+     * @return array
+     */
+    public function __invoke()
+    {
+        return [
+            'dependencies' => $this->getDependencyConfig(),
+            'filters'      => $this->getFilterConfig(),
+            'validators'   => $this->getValidatorConfig(),
+            'view_helpers' => $this->getViewHelperConfig(),
+        ];
+    }
+
+    /**
+     * Return application-level dependency configuration.
+     *
+     * @return array
+     */
+    public function getDependencyConfig()
+    {
+        return [
+            'aliases' => [
+                'TranslatorPluginManager' => Translator\LoaderPluginManager::class,
+            ],
+            'factories' => [
+                Translator\TranslatorInterface::class => Translator\TranslatorServiceFactory::class,
+                Translator\LoaderPluginManager::class => Translator\LoaderPluginManagerFactory::class,
+            ],
+        ];
+    }
+
+    /**
+     * Return zend-filter configuration.
+     *
+     * @return array
+     */
+    public function getFilterConfig()
+    {
+        return [
+            'aliases' => [
+                'alnum'        => Filter\Alnum::class,
+                'Alnum'        => Filter\Alnum::class,
+                'alpha'        => Filter\Alpha::class,
+                'Alpha'        => Filter\Alpha::class,
+                'numberformat' => Filter\NumberFormat::class,
+                'numberFormat' => Filter\NumberFormat::class,
+                'NumberFormat' => Filter\NumberFormat::class,
+                'numberparse'  => Filter\NumberParse::class,
+                'numberParse'  => Filter\NumberParse::class,
+                'NumberParse'  => Filter\NumberParse::class,
+            ],
+            'factories' => [
+                Filter\Alnum::class        => InvokableFactory::class,
+                Filter\Alpha::class        => InvokableFactory::class,
+                Filter\NumberFormat::class => InvokableFactory::class,
+                Filter\NumberParse::class  => InvokableFactory::class,
+            ],
+        ];
+    }
+
+    /**
+     * Return zend-validator configuration.
+     *
+     * @return array
+     */
+    public function getValidatorConfig()
+    {
+        return [
+            'aliases' => [
+                'alnum'       => Validator\Alnum::class,
+                'Alnum'       => Validator\Alnum::class,
+                'alpha'       => Validator\Alpha::class,
+                'Alpha'       => Validator\Alpha::class,
+                'datetime'    => Validator\DateTime::class,
+                'dateTime'    => Validator\DateTime::class,
+                'DateTime'    => Validator\DateTime::class,
+                'float'       => Validator\IsFloat::class,
+                'Float'       => Validator\IsFloat::class,
+                'int'         => Validator\IsInt::class,
+                'Int'         => Validator\IsInt::class,
+                'isfloat'     => Validator\IsFloat::class,
+                'isFloat'     => Validator\IsFloat::class,
+                'IsFloat'     => Validator\IsFloat::class,
+                'isint'       => Validator\IsInt::class,
+                'isInt'       => Validator\IsInt::class,
+                'IsInt'       => Validator\IsInt::class,
+                'phonenumber' => Validator\PhoneNumber::class,
+                'phoneNumber' => Validator\PhoneNumber::class,
+                'PhoneNumber' => Validator\PhoneNumber::class,
+                'postcode'    => Validator\PostCode::class,
+                'postCode'    => Validator\PostCode::class,
+                'PostCode'    => Validator\PostCode::class,
+            ],
+            'factories' => [
+                Validator\Alnum::class       => InvokableFactory::class,
+                Validator\Alpha::class       => InvokableFactory::class,
+                Validator\DateTime::class    => InvokableFactory::class,
+                Validator\IsFloat::class     => InvokableFactory::class,
+                Validator\IsInt::class       => InvokableFactory::class,
+                Validator\PhoneNumber::class => InvokableFactory::class,
+                Validator\PostCode::class    => InvokableFactory::class,
+            ],
+        ];
+    }
+
+    /**
+     * Return zend-view helper configuration.
+     *
+     * Obsoletes View\HelperConfig.
+     *
+     * @return array
+     */
+    public function getViewHelperConfig()
+    {
+        return [
+            'aliases' => [
+                'currencyformat'  => View\Helper\CurrencyFormat::class,
+                'currencyFormat'  => View\Helper\CurrencyFormat::class,
+                'CurrencyFormat'  => View\Helper\CurrencyFormat::class,
+                'dateformat'      => View\Helper\DateFormat::class,
+                'dateFormat'      => View\Helper\DateFormat::class,
+                'DateFormat'      => View\Helper\DateFormat::class,
+                'numberformat'    => View\Helper\NumberFormat::class,
+                'numberFormat'    => View\Helper\NumberFormat::class,
+                'NumberFormat'    => View\Helper\NumberFormat::class,
+                'plural'          => View\Helper\Plural::class,
+                'Plural'          => View\Helper\Plural::class,
+                'translate'       => View\Helper\Translate::class,
+                'Translate'       => View\Helper\Translate::class,
+                'translateplural' => View\Helper\TranslatePlural::class,
+                'translatePlural' => View\Helper\TranslatePlural::class,
+                'TranslatePlural' => View\Helper\TranslatePlural::class,
+            ],
+            'factories' => [
+                View\Helper\CurrencyFormat::class  => InvokableFactory::class,
+                View\Helper\DateFormat::class      => InvokableFactory::class,
+                View\Helper\NumberFormat::class    => InvokableFactory::class,
+                View\Helper\Plural::class          => InvokableFactory::class,
+                View\Helper\Translate::class       => InvokableFactory::class,
+                View\Helper\TranslatePlural::class => InvokableFactory::class,
+            ],
+        ];
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-i18n for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\I18n;
+
+class Module
+{
+    /**
+     * Return zend-i18n configuration for zend-mvc application.
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+        $provider = new ConfigProvider();
+        return [
+            'filters'         => $provider->getFilterConfig(),
+            'service_manager' => $provider->getDependencyConfig(),
+            'validators'      => $provider->getValidatorConfig(),
+            'view_helpers'    => $provider->getViewHelperConfig(),
+        ];
+    }
+}

--- a/src/Translator/LoaderPluginManagerFactory.php
+++ b/src/Translator/LoaderPluginManagerFactory.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-i18n for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\I18n\Translator;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class LoaderPluginManagerFactory implements FactoryInterface
+{
+    /**
+     * zend-servicemanager v2 options passed to factory.
+     *
+     * @param array
+     */
+    protected $creationOptions = [];
+
+    /**
+     * Create and return a LoaderPluginManager.
+     *
+     * @param ContainerInterface $container
+     * @param string $name
+     * @param null|array $options
+     * @return LoaderPluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        $options = $options ?: [];
+        return new LoaderPluginManager($container, $options);
+    }
+
+    /**
+     * zend-servicemanager v2 factory to return LoaderPluginManager
+     *
+     * @param ServiceLocatorInterface $container
+     * @return LoaderPluginManager
+     */
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, 'TranslatorPluginManager', $this->creationOptions);
+    }
+
+    /**
+     * v2 support for instance creation options.
+     *
+     * @param array $options
+     * @return void
+     */
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}

--- a/src/View/HelperConfig.php
+++ b/src/View/HelperConfig.php
@@ -15,6 +15,8 @@ use Zend\ServiceManager\ServiceManager;
 
 /**
  * Service manager configuration for i18n view helpers.
+ *
+ * @deprecated since 2.7.0; replaced by ConfigProvider and Module class.
  */
 class HelperConfig implements ConfigInterface
 {

--- a/test/Translator/LoaderPluginManagerFactoryTest.php
+++ b/test/Translator/LoaderPluginManagerFactoryTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-i18n for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\I18n\Translator;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\I18n\Translator\LoaderPluginManager;
+use Zend\I18n\Translator\LoaderPluginManagerFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class LoaderPluginManagerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsUnconfiguredPluginManagerWhenNoOptionsPresent()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+
+        $factory = new LoaderPluginManagerFactory();
+        $loaders = $factory($container, 'TranslatorPluginManager');
+        $this->assertInstanceOf(LoaderPluginManager::class, $loaders);
+        $this->assertFalse($loaders->has('test'));
+    }
+
+    public function testCreateServiceReturnsUnconfiguredPluginManagerWhenNoOptionsPresent()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $factory = new LoaderPluginManagerFactory();
+        $loaders = $factory->createService($container->reveal());
+        $this->assertInstanceOf(LoaderPluginManager::class, $loaders);
+        $this->assertFalse($loaders->has('test'));
+    }
+
+    public function testFactoryCanConfigurePluginManagerViaOptions()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+
+        $factory = new LoaderPluginManagerFactory();
+        $loaders = $factory($container, 'TranslatorPluginManager', ['aliases' => [
+            'test' => 'phparray',
+        ]]);
+        $this->assertInstanceOf(LoaderPluginManager::class, $loaders);
+        $this->assertTrue($loaders->has('test'));
+    }
+
+    public function testCreateServiceCanConfigurePluginManagerViaOptions()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $factory = new LoaderPluginManagerFactory();
+        $factory->setCreationOptions(['aliases' => [
+            'test' => 'phparray',
+        ]]);
+        $loaders = $factory->createService($container->reveal());
+        $this->assertInstanceOf(LoaderPluginManager::class, $loaders);
+        $this->assertTrue($loaders->has('test'));
+    }
+}


### PR DESCRIPTION
This patch imports functionality that is zend-i18n-specific, but only available in zend-mvc; specifically, the `TranslatorPluginManager` factory. Additionally, it creates both a `ConfigProvider` and a `Module` class in the top-level namespace, providing configuration for:
- The `TranslatorInterface` service and the `TranslatorPluginManager`.
- Filters exposed by zend-i18n.
- Validators exposed by zend-i18n.
- View helpers exposed by zend-i18n (obviating the need for `Zend\I18n\View\HelperConfig`).

The `ConfigProvider` and `TranslatorPluginManager` are exposed to [zend-component-installer](https://zendframework.github.io/zend-component-installer/) via the `composer.json`.

This functionality can be released with an immediate 2.7.0 release without conflict, allowing usage with [zend-expressive](https://zendframework.github.io/zend-expressive), and development versions of zend-mvc (where the parallel functionality can now be removed).
