### PR TITLE
Added test to check if possible to set country with context

### DIFF
--- a/src/Validator/PhoneNumber.php
+++ b/src/Validator/PhoneNumber.php
@@ -154,7 +154,7 @@ class PhoneNumber extends AbstractValidator
      */
     public function setCountry($country)
     {
-        $this->country = strtoupper($country);
+        $this->country = $country;
 
         return $this;
     }
@@ -201,12 +201,12 @@ class PhoneNumber extends AbstractValidator
 
         $country = $this->getCountry();
 
-        if (!$countryPattern = $this->loadPattern($country)) {
+        if (!$countryPattern = $this->loadPattern(strtoupper($country))) {
             if (isset($context[$country])) {
                 $country = $context[$country];
             }
 
-            if (!$countryPattern = $this->loadPattern($country)) {
+            if (!$countryPattern = $this->loadPattern(strtoupper($country))) {
                 $this->error(self::UNSUPPORTED);
 
                 return false;

--- a/test/Validator/PhoneNumberTest.php
+++ b/test/Validator/PhoneNumberTest.php
@@ -3202,4 +3202,14 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
             }
         }
     }
+
+    public function testCanSpecifyCountryWithContext()
+    {
+        Locale::setDefault('ZW');
+        $validator = new PhoneNumber([
+            'country' => 'country-code',
+        ]);
+
+        $this->assertTrue($validator->isValid('+37067811268', ['country-code' => 'LT']));
+    }
 }

--- a/test/Validator/PhoneNumberTest.php
+++ b/test/Validator/PhoneNumberTest.php
@@ -3164,10 +3164,12 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->validator->allowPossible());
     }
 
-    public function testSetCountryMethodIsCaseInsensitive()
+    public function testCountryIsCaseInsensitive()
     {
-        $this->validator->setCountry('us');
-        $this->assertSame('US', $this->validator->getCountry());
+        $this->validator->setCountry('lt');
+        $this->assertTrue($this->validator->isValid('+37067811268'));
+        $this->validator->setCountry('LT');
+        $this->assertTrue($this->validator->isValid('+37067811268'));
     }
 
     /**


### PR DESCRIPTION
I guess this was desired behavior but didn't worked.

this is extremely useful for example with input filters, example:

``` php
class User extends InputFilter
{
    public function __construct()
    {
        $this->add([
            'name'       => 'country_code',
            'required'   => true,
            'validators' => [
                new CountryCode()
            ],
        ]);
        $this->add([
            'name'       => 'phone',
            'required'   => true,
            'validators' => [
                [
                    'name' => 'PhoneNumber',
                    'options' => [
                        'country' => 'country_code',
                    ]
                ],
        ]);
    }
}
```

before I had to wrap `PhoneNumber` into `callback` validator and pass country in constructor.
