### PR TITLE
Fix the module initializer

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -28,11 +28,12 @@ class Module
     /**
      * Register a specification for the TranslatorPluginManager with the ServiceListener.
      *
-     * @param \Zend\ModuleManager\ModuleEvent
+     * @param \Zend\ModuleManager\ModuleManager $moduleManager
      * @return void
      */
-    public function init($event)
+    public function init($moduleManager)
     {
+        $event = $moduleManager->getEvent();
         $container = $event->getParam('ServiceManager');
         $serviceListener = $container->get('ServiceListener');
 

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -44,6 +44,9 @@ class ModuleTest extends TestCase
         $event = $this->prophesize(TestAsset\ModuleEventInterface::class);
         $event->getParam('ServiceManager')->willReturn($container->reveal());
 
-        $this->assertNull($this->module->init($event->reveal()));
+        $moduleManager = $this->prophesize(TestAsset\ModuleManagerInterface::class);
+        $moduleManager->getEvent()->willReturn($event->reveal());
+
+        $this->assertNull($this->module->init($moduleManager->reveal()));
     }
 }

--- a/test/TestAsset/ModuleManagerInterface.php
+++ b/test/TestAsset/ModuleManagerInterface.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-i18n for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\I18n\TestAsset;
+
+interface ModuleManagerInterface
+{
+    public function getEvent();
+}


### PR DESCRIPTION
Initializers actually receive the module manager itself, not the module event. As such, we have to pull the event from the module manager instance.
