### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - secure: "ACz/CDPU1Nv2mqQL7UZaULiHrlIafQW/ytNc8ijY1fLwrEt1uglh0bqwmW8mu0PN+dcKUTveDSLR2SPUiyXRkUZkehET9pl+Et4gYQ+4ulxvN4El1lQsGHky+xlAVVDuX5v9yWd+0k8FbklDdVmPc6EpXDCj+ul9noMg90K283Fe5/nRmZTmBBCkxBFLsXSmtiCWpuTuWIdGxz4rdTtl8LcpYQx/oxMy5e50HTbgmUfEEr9yeEfw/i0RWCo6+fjM/y+ZB0IHApDYMmR5yp0ZmFm+d/ISmd1rdmYxgrsUAIWwfd7Q/ukF4C0iZVfg1q14bLJqVkCxPJlNVjbFxbJ0EfpyJJqpQPNvHMo92BqbcRDcBSfwoRyeiE0vyH/T2ni38ZuA16qOd/WJILtNHtPVesyJQV5D2vi8b2fAq2givp28/BxXC/7RVzvyv2INZJXrjrJkbbzphf6bAxxyrvDlE+i01N/yy84bkDHMzdQstDLMC0sZa2GicZDg6box/BlquXjy75n+NBYBfyBhftKIJkeDoSPSZxUWfbm7EX1GoPzl1AbTKhhTlbWLMp1jhJQyi2KjrkpyYtS2IH6vnH1fc85QdZhrRfrHDpHm5+kQ5pbPW/pCDX/1BwPJQ9CZELoENicX1r4uzZA2M1hCzrSEbKyapMC8SmoJ4pdOybAn7Ow="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.5
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
