### PR TITLE
Add the ability to set a default translator and text domain

### DIFF
--- a/doc/book/view-helpers.md
+++ b/doc/book/view-helpers.md
@@ -563,3 +563,46 @@ getTranslatorTextDomain() : string
 ```
 
 Returns the current text domain used by the helper.
+
+#### AbstractValidator::setDefaultTranslator()
+
+```php
+AbstractValidator::setDefaultTranslator(
+    Translator $translator = null,
+    $textDomain = null
+) : void
+```
+
+Set default translation object for all view helpers
+
+#### AbstractValidator::getDefaultTranslator()
+
+```php
+AbstractValidator::getDefaultTranslator() : Translator
+```
+
+Get default translation object for all view helpers
+
+#### AbstractValidator::hasDefaultTranslator()
+
+```php
+AbstractValidator::hasDefaultTranslator() : bool
+```
+
+Returns true if there is a default translation object set.
+
+#### AbstractValidator::setDefaultTranslatorTextDomain()
+
+```php
+AbstractValidator::setDefaultTranslatorTextDomain($textDomain = 'default') : void
+```
+
+Set default translation text domain for all view helpers
+
+#### AbstractValidator::getDefaultTranslatorTextDomain()
+
+```php
+AbstractValidator::getDefaultTranslatorTextDomain() : string
+```
+
+Get default translation text domain for all view helpers

--- a/src/View/Helper/AbstractTranslatorHelper.php
+++ b/src/View/Helper/AbstractTranslatorHelper.php
@@ -28,7 +28,7 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
      *
      * @var string
      */
-    protected $translatorTextDomain = 'default';
+    protected $translatorTextDomain = null;
 
     /**
      * Whether translator should be used
@@ -36,6 +36,18 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
      * @var bool
      */
     protected $translatorEnabled = true;
+
+    /**
+     * Default translation object for all view helpers
+     * @var Translator
+     */
+    protected static $defaultTranslator;
+
+    /**
+     * Default text domain to be used with translator
+     * @var string
+     */
+    protected static $defaultTranslatorTextDomain = 'default';
 
     /**
      * Sets translator to use in helper
@@ -65,6 +77,10 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
     {
         if (! $this->isTranslatorEnabled()) {
             return;
+        }
+
+        if (self::hasDefaultTranslator()) {
+            $this->translator = self::getDefaultTranslator();
         }
 
         return $this->translator;
@@ -121,6 +137,65 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
      */
     public function getTranslatorTextDomain()
     {
+        if ($this->translatorTextDomain === null) {
+            $this->translatorTextDomain = self::getDefaultTranslatorTextDomain();
+        }
         return $this->translatorTextDomain;
+    }
+
+    /**
+     * Set default translation object for all view helpers
+     *
+     * @param  Translator|null $translator
+     * @param  string          $textDomain (optional)
+     * @return void
+     */
+    public static function setDefaultTranslator(Translator $translator = null, $textDomain = null)
+    {
+        static::$defaultTranslator = $translator;
+        if (null !== $textDomain) {
+            self::setDefaultTranslatorTextDomain($textDomain);
+        }
+    }
+
+    /**
+     * Get default translation object for all view helpers
+     *
+     * @return Translator|null
+     */
+    public static function getDefaultTranslator()
+    {
+        return static::$defaultTranslator;
+    }
+
+    /**
+     * Is there a default translation object set?
+     *
+     * @return bool
+     */
+    public static function hasDefaultTranslator()
+    {
+        return (bool) static::$defaultTranslator;
+    }
+
+    /**
+     * Set default translation text domain for all view helpers
+     *
+     * @param  string $textDomain
+     * @return void
+     */
+    public static function setDefaultTranslatorTextDomain($textDomain = 'default')
+    {
+        static::$defaultTranslatorTextDomain = $textDomain;
+    }
+
+    /**
+     * Get default translation text domain for all view helpers
+     *
+     * @return string
+     */
+    public static function getDefaultTranslatorTextDomain()
+    {
+        return static::$defaultTranslatorTextDomain;
     }
 }

--- a/test/View/Helper/TranslateTest.php
+++ b/test/View/Helper/TranslateTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\I18n\View\Helper;
 
+use Zend\I18n\View\Helper\AbstractTranslatorHelper;
 use Zend\I18n\View\Helper\Translate as TranslateHelper;
 
 /**
@@ -82,5 +83,25 @@ class TranslateTest extends \PHPUnit_Framework_TestCase
         $this->helper->setTranslator($translatorMock);
 
         $this->assertEquals($expected, $this->helper->__invoke($input, $textDomain, $locale));
+    }
+
+    public function testCustomInvokeArgumentsUsingDefaultTranslator()
+    {
+        $input      = 'input';
+        $expected   = 'translated';
+        $textDomain = 'textDomain';
+        $locale     = 'en_US';
+
+        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
+        $translatorMock->expects($this->once())
+            ->method('translate')
+            ->with($this->equalTo($input), $this->equalTo($textDomain), $this->equalTo($locale))
+            ->will($this->returnValue($expected));
+
+        AbstractTranslatorHelper::setDefaultTranslator($translatorMock, $textDomain);
+
+        $this->assertEquals($expected, $this->helper->__invoke($input, $textDomain, $locale));
+
+        AbstractTranslatorHelper::setDefaultTranslator(null, 'default');
     }
 }


### PR DESCRIPTION
Discussed in https://github.com/zendframework/zend-form/pull/115:

Ive added the ability to set a default translator and text domain to avoid having to set them  to every View-Helper.
Because I've wanted to change the text domain of every view helper and right now I have to instantiate every view helper to set it. This would reduce the overhead necessary and increase the runtime performance.
Another possibility would be an initializer that sets the appropriate translator and domain upon instantiation of a view helper.

The concrete implementation is a straight up copy of zend-validator with some small tweaks.

Any thoughts on this?
