### PR TITLE
Fix for gettext with defined text_domain

### DIFF
--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -446,6 +446,24 @@ class Translator implements TranslatorInterface
             return $this->messages[$textDomain][$locale][$message];
         }
 
+
+        /**
+         * issue https://github.com/zendframework/zend-i18n/issues/53
+         *
+         * storage: array:8 [▼
+         *   "default\x04Welcome" => "Cześć"
+         *   "default\x04Top %s Product" => array:3 [▼
+         *     0 => "Top %s Produkt"
+         *     1 => "Top %s Produkty"
+         *     2 => "Top %s Produktów"
+         *   ]
+         *   "Top %s Products" => ""
+         * ]
+         */
+        if (isset($this->messages[$textDomain][$locale][$textDomain . "\x04" . $message])) {
+            return $this->messages[$textDomain][$locale][$textDomain . "\x04" . $message];
+        }
+
         if ($this->isEventManagerEnabled()) {
             $until = function ($r) {
                 return is_string($r);


### PR DESCRIPTION
Ex. 1 - Missing translations with defined text_domain in PoEdit Source keywords:
`translate:1,2c`
`translatePlural:1,2,4c`

Ex. 2 - Working PoEdit Source keywords (but without text_domain):
`translate:1`
`translatePlural:1,2`

Cause:
Gettext with defined text_domain gives `\x04' EOT in storage array key
Ex. 1 `ui\x04name`
Ex. 2`name`

Resolves zendframework/zend-i18n#53