### PR TITLE
Improve PostCode validator for Ireland (IE) to support Eircode

### DIFF
--- a/src/Validator/PostCode.php
+++ b/src/Validator/PostCode.php
@@ -124,7 +124,7 @@ class PostCode extends AbstractValidator
         'IS' => '\d{3}',
         'IN' => '\d{6}',
         'ID' => '\d{5}',
-        'IE' => '((D|DUBLIN)?([1-9]|6[wW]|1[0-8]|2[024]))?',
+        'IE' => '[\dA-Z]{3} ?[\dA-Z]{4}',
         'IL' => '\d{5}',
         'JO' => '\d{5}',
         'KZ' => '\d{6}',


### PR DESCRIPTION
Improve PostCode validator for Ireland (IE) to support Eircode (see https://www.eircode.ie/what-is-eircode).