### PR TITLE
ICU workaround for currency standing at the end of formatted number #72

### DIFF
--- a/src/View/Helper/CurrencyFormat.php
+++ b/src/View/Helper/CurrencyFormat.php
@@ -151,9 +151,16 @@ class CurrencyFormat extends AbstractHelper
 
         $formattedNumber = $this->formatters[$formatterId]->formatCurrency($number, $currencyCode);
 
-        return $this->correctionNeeded
-            ? $this->correctICUBug($formattedNumber, $this->formatters[$formatterId])
-            : $formattedNumber;
+        if ($this->correctionNeeded) {
+            $formattedNumber = $this->fixICUBugForNoDecimals(
+                $formattedNumber,
+                $this->formatters[$formatterId],
+                $locale,
+                $currencyCode
+            );
+        }
+
+        return $formattedNumber;
     }
 
     /**
@@ -251,14 +258,36 @@ class CurrencyFormat extends AbstractHelper
 
 
     /**
-     * @param string $formattedNumber
+     * @param string          $formattedNumber
      * @param NumberFormatter $formatter
+     * @param string          $locale
+     * @param string          $currencyCode
+     *
      * @return string
      */
-    private function correctICUBug($formattedNumber, NumberFormatter $formatter)
+    private function fixICUBugForNoDecimals($formattedNumber, NumberFormatter $formatter, $locale, $currencyCode)
     {
-        $pattern = sprintf('/\%s\d+$/', $formatter->getSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL));
+        $pattern = sprintf(
+            '/\%s\d+(\s?%s)?$/u',
+            $formatter->getSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL),
+            preg_quote($this->getCurrencySymbol($locale, $currencyCode))
+        );
 
-        return preg_replace($pattern, '', $formattedNumber);
+        return preg_replace($pattern, '$1', $formattedNumber);
+    }
+
+
+
+    /**
+     * @param string $locale
+     * @param string $currencyCode
+     *
+     * @return string
+     */
+    private function getCurrencySymbol($locale, $currencyCode)
+    {
+        $numberFormatter = new NumberFormatter($locale . '@currency=' . $currencyCode, NumberFormatter::CURRENCY);
+
+        return $numberFormatter->getSymbol(NumberFormatter::CURRENCY_SYMBOL);
     }
 }

--- a/test/View/Helper/CurrencyFormatTest.php
+++ b/test/View/Helper/CurrencyFormatTest.php
@@ -58,7 +58,7 @@ class CurrencyFormatTest extends TestCase
             ['de_AT', 'EUR',       false, 1234.56,                 null,                       '€ 1.235'],
             ['de_AT', 'EUR',       false, 0.123,                   null,                       '€ 0'],
             ['de_DE', 'EUR',       false, 1234567.891234567890000, null,                       '1.234.568 €'],
-            ['de_DE', 'RUB',       false, 1234567.891234567890000, null,                       '1.234.567,89 RUB'],
+            ['de_DE', 'RUB',       false, 1234567.891234567890000, null,                       '1.234.567 RUB'],
             //array('ru_RU', 'EUR',     false,             1234567.891234567890000,  null, '1 234 568 €'),
             //array('ru_RU', 'RUR',     false,             1234567.891234567890000,  null, '1 234 567 р.'),
             //array('en_US', 'EUR',     false,             1234567.891234567890000,  null, '€1,234,568'),
@@ -66,6 +66,9 @@ class CurrencyFormatTest extends TestCase
             ['en_US', 'USD',       false, 1234567.891234567890000, null,                       '$1,234,568'],
             /* @see http://bugs.icu-project.org/trac/ticket/10997 */
             ['en_US', 'EUR',       false, 1234567.891234567890000, null,                       '€1,234,567'],
+            ['de_DE', 'USD',       false, 1234567.891234567890000, null,                       '1.234.567 $'],
+            ['en_US', 'PLN',       false, 1234567.891234567890000, null,                       'PLN 1,234,567'],
+            ['de_DE', 'PLN',       false, 1234567.891234567890000, null,                       '1.234.567 PLN'],
         ];
     }
 


### PR DESCRIPTION
This code extend my original implentation because original one was relying on currency position to be fixed. But that is not true in some cases.