### PR TITLE
LV post code accepts LV- prefix

### DIFF
--- a/src/Validator/PostCode.php
+++ b/src/Validator/PostCode.php
@@ -132,7 +132,7 @@ class PostCode extends AbstractValidator
         'KE' => '\d{5}',
         'KW' => '\d{5}',
         'LA' => '\d{5}',
-        'LV' => '\d{4}',
+        'LV' => '(LV-)?\d{4}',
         'LB' => '(\d{4}([ ]?\d{4})?)?',
         'LI' => '(948[5-9])|(949[0-7])',
         'LT' => '\d{5}',

--- a/test/Validator/PostCodeTest.php
+++ b/test/Validator/PostCodeTest.php
@@ -241,4 +241,21 @@ class PostCodeTest extends TestCase
         $this->assertTrue($validator->isValid('9910')); // BJØRNEVATN
         $this->assertFalse($validator->isValid('0000')); // Postal code 0000
     }
+
+    /**
+     * Postal codes in Latvia are 4 digit numeric and use a mandatory ISO 3166-1 alpha-2 country code (LV) in front,
+     * i.e. the format is “LV-NNNN”.
+     * To prevent BC break LV- prefix is optional
+     * https://en.wikipedia.org/wiki/Postal_codes_in_Latvia
+     */
+    public function testLvPostCodes()
+    {
+        $validator = $this->validator;
+        $validator->setLocale('en_LV');
+
+        $this->assertTrue($validator->isValid('LV-0000'));
+        $this->assertTrue($validator->isValid('0000'));
+        $this->assertFalse($validator->isValid('ABCD'));
+        $this->assertFalse($validator->isValid('LV-ABCD'));
+    }
 }


### PR DESCRIPTION
[Postal codes in Latvia](https://en.wikipedia.org/wiki/Postal_codes_in_Latvia) are 4 digit numeric and use a mandatory ISO 3166-1 alpha-2 country code (LV) in front, i.e. the format is **LV-NNNN**.

So I changed LV regex to accept the **LV-** prefix.