### PR TITLE
fix tests for recent ICU version

### DIFF
--- a/test/Validator/IsFloatTest.php
+++ b/test/Validator/IsFloatTest.php
@@ -167,7 +167,7 @@ class IsFloatTest extends TestCase
             'ar'    => ['10.1', '66notflot.6'],
             'ru'    => ['10.1', '66notflot.6', '2,000.00', '2 00'],
             'en'    => ['10,1', '66notflot.6', '2.000,00', '2 000', '2,00'],
-            'fr-CH' => ['10,1', '66notflot.6', '2,000.00', "2'00"]
+            'fr-CH' => ['66notflot.6', '2,000.00', "2'00"]
         ];
 
         //Loop locales and examples for a more thorough set of "true" test data

--- a/test/View/Helper/CurrencyFormatTest.php
+++ b/test/View/Helper/CurrencyFormatTest.php
@@ -43,11 +43,6 @@ class CurrencyFormatTest extends TestCase
     {
         return [
             //    locale   currency     show decimals       number      currencyPattern             expected
-            ['de_AT', 'EUR',       true,               1234.56,    null,                       '€ 1.234,56'],
-            ['de_AT', 'EUR',       true,               0.123,      null,                       '€ 0,12'],
-            ['de_AT', 'EUR',       true,               0.123,      '#,##0.00 ¤',               '0,12 €'],
-            ['de_AT', 'EUR',       true,               -0.123,     '#,##0.00 ¤; ¤ - #,##0.00', ' € - 0,12'],
-            ['de_AT', 'EUR',       true,               -0.123,     '¤ #,##0.00; - ¤ #,##0.00', '- € 0,12'],
             ['de_DE', 'EUR',       true, 1234567.891234567890000,  null,                       '1.234.567,89 €'],
             ['de_DE', 'RUR',       true, 1234567.891234567890000,  null,                       '1.234.567,89 RUR'],
             ['ru_RU', 'EUR',       true, 1234567.891234567890000,  null,                       '1 234 567,89 €'],
@@ -55,8 +50,6 @@ class CurrencyFormatTest extends TestCase
             ['en_US', 'EUR',       true, 1234567.891234567890000,  null,                       '€1,234,567.89'],
             ['en_US', 'RUR',       true, 1234567.891234567890000,  null,                       'RUR1,234,567.89'],
             ['en_US', 'USD',       true, 1234567.891234567890000,  null,                       '$1,234,567.89'],
-            ['de_AT', 'EUR',       false, 1234.56,                 null,                       '€ 1.235'],
-            ['de_AT', 'EUR',       false, 0.123,                   null,                       '€ 0'],
             ['de_DE', 'EUR',       false, 1234567.891234567890000, null,                       '1.234.568 €'],
             ['de_DE', 'RUB',       false, 1234567.891234567890000, null,                       '1.234.567,89 RUB'],
             //array('ru_RU', 'EUR',     false,             1234567.891234567890000,  null, '1 234 568 €'),


### PR DESCRIPTION
Fix #14 

And new issue with ICU 60, from Fedora QA
https://apps.fedoraproject.org/koschei/package/php-zendframework-zend-i18n

```
There was 1 failure:
1) ZendTest\I18n\Validator\IsFloatTest::testValidationFailures with data set #11 ('10,1', false, 'fr-CH')
Failed expecting 10,1 being false (locale:fr-CH)
Failed asserting that true matches expected false.
/builddir/build/BUILD/zend-i18n-d3431e29cc00c2a1c6704e601d4371dbf24f6a31/test/Validator/IsFloatTest.php:159

```