### PR TITLE
fallback to sourcecode if pluralform exists but is not translated

### DIFF
--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -404,18 +404,17 @@ class Translator implements TranslatorInterface
             return $translation[$index];
         }
 
-        if (
-            null !== ($fallbackLocale = $this->getFallbackLocale())
+        if (null !== ($fallbackLocale = $this->getFallbackLocale())
             && $locale !== $fallbackLocale
         ) {
-        return $this->translatePlural(
-            $singular,
-            $plural,
-            $number,
-            $textDomain,
-            $fallbackLocale
-        );
-    }
+            return $this->translatePlural(
+                $singular,
+                $plural,
+                $number,
+                $textDomain,
+                $fallbackLocale
+            );
+        }
 
         return $index === 0 ? $singular : $plural;
     }

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -389,37 +389,33 @@ class Translator implements TranslatorInterface
         $locale      = $locale ?: $this->getLocale();
         $translation = $this->getTranslatedMessage($singular, $locale, $textDomain);
 
-        if ($translation === null || $translation === '') {
-            if (null !== ($fallbackLocale = $this->getFallbackLocale())
-                && $locale !== $fallbackLocale
-            ) {
-                return $this->translatePlural(
-                    $singular,
-                    $plural,
-                    $number,
-                    $textDomain,
-                    $fallbackLocale
-                );
-            }
-
-            return ($number == 1 ? $singular : $plural);
-        } elseif (is_string($translation)) {
+        if (is_string($translation)) {
             $translation = [$translation];
         }
 
-        $index = $this->messages[$textDomain][$locale]
-                      ->getPluralRule()
-                      ->evaluate($number);
-
-        if (! isset($translation[$index])) {
-            throw new Exception\OutOfBoundsException(
-                sprintf('Provided index %d does not exist in plural array', $index)
-            );
+        $index = ($number === 1) ? 0 : 1; // en_EN Plural rule
+        if ($this->messages[$textDomain][$locale] instanceof TextDomain) {
+            $index = $this->messages[$textDomain][$locale]
+                ->getPluralRule()
+                ->evaluate($number);
         }
 
-        if ($translation[$index] !== '') {
+        if (isset($translation[$index]) && $translation[$index] !== '' && $translation[$index] !== null) {
             return $translation[$index];
         }
+
+        if (
+            null !== ($fallbackLocale = $this->getFallbackLocale())
+            && $locale !== $fallbackLocale
+        ) {
+        return $this->translatePlural(
+            $singular,
+            $plural,
+            $number,
+            $textDomain,
+            $fallbackLocale
+        );
+    }
 
         return $index === 0 ? $singular : $plural;
     }

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -417,7 +417,11 @@ class Translator implements TranslatorInterface
             );
         }
 
-        return $translation[$index];
+        if ($translation[$index] !== '') {
+            return $translation[$index];
+        }
+
+        return $index === 0 ? $singular : $plural;
     }
 
     /**

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -257,6 +257,44 @@ class TranslatorTest extends TestCase
         $this->assertEquals('Message 5 (en) Plural 2', $pl2);
     }
 
+	public function testTranslatePluralsNonExistantLocale()
+	{
+		$this->translator->addTranslationFilePattern(
+			'phparray',
+			$this->testFilesDir . '/testarray',
+			'translation-%s.php'
+		);
+
+		$this->translator->setLocale('es_ES');
+
+		$pl0 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 1);
+		$pl1 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 2);
+		$pl2 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 10);
+
+		$this->assertEquals('Message 5', $pl0);
+		$this->assertEquals('Message 5 Plural', $pl1);
+		$this->assertEquals('Message 5 Plural', $pl2);
+	}
+
+	public function testTranslatePluralsNonExistantTranslation()
+	{
+		$this->translator->addTranslationFilePattern(
+			'phparray',
+			$this->testFilesDir . '/testarray',
+			'translation-%s.php'
+		);
+
+		$this->translator->setLocale('de_DE');
+
+		$pl0 = $this->translator->translatePlural('Message 12', 'Message 12 Plural', 1);
+		$pl1 = $this->translator->translatePlural('Message 12', 'Message 12 Plural', 2);
+		$pl2 = $this->translator->translatePlural('Message 12', 'Message 12 Plural', 10);
+
+		$this->assertEquals('Message 12', $pl0);
+		$this->assertEquals('Message 12 Plural', $pl1);
+		$this->assertEquals('Message 12 Plural', $pl2);
+	}
+
     public function testTranslateNoPlurals()
     {
         // Some languages such as Japanese and Chinese does not have plural forms
@@ -297,6 +335,21 @@ class TranslatorTest extends TestCase
         $this->assertEquals('Message 1', $this->translator->translate('Message 1'));
         $this->assertEquals('Message 9', $this->translator->translate('Message 9'));
     }
+
+	public function testTranslateNonExistantTranslation()
+	{
+		$this->translator->addTranslationFilePattern(
+			'phparray',
+			$this->testFilesDir . '/testarray',
+			'translation-%s.php'
+		);
+
+		// Test that a locale without translations does not cause warnings
+
+		$this->translator->setLocale('de_DE');
+
+		$this->assertEquals('Message 13', $this->translator->translate('Message 13'));
+	}
 
     public function testEnableDisableEventManger()
     {

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -257,43 +257,43 @@ class TranslatorTest extends TestCase
         $this->assertEquals('Message 5 (en) Plural 2', $pl2);
     }
 
-	public function testTranslatePluralsNonExistantLocale()
-	{
-		$this->translator->addTranslationFilePattern(
-			'phparray',
-			$this->testFilesDir . '/testarray',
-			'translation-%s.php'
-		);
+    public function testTranslatePluralsNonExistantLocale()
+    {
+        $this->translator->addTranslationFilePattern(
+            'phparray',
+            $this->testFilesDir . '/testarray',
+            'translation-%s.php'
+        );
 
-		$this->translator->setLocale('es_ES');
+        $this->translator->setLocale('es_ES');
 
-		$pl0 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 1);
-		$pl1 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 2);
-		$pl2 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 10);
+        $pl0 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 1);
+        $pl1 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 2);
+        $pl2 = $this->translator->translatePlural('Message 5', 'Message 5 Plural', 10);
 
-		$this->assertEquals('Message 5', $pl0);
-		$this->assertEquals('Message 5 Plural', $pl1);
-		$this->assertEquals('Message 5 Plural', $pl2);
-	}
+        $this->assertEquals('Message 5', $pl0);
+        $this->assertEquals('Message 5 Plural', $pl1);
+        $this->assertEquals('Message 5 Plural', $pl2);
+    }
 
-	public function testTranslatePluralsNonExistantTranslation()
-	{
-		$this->translator->addTranslationFilePattern(
-			'phparray',
-			$this->testFilesDir . '/testarray',
-			'translation-%s.php'
-		);
+    public function testTranslatePluralsNonExistantTranslation()
+    {
+        $this->translator->addTranslationFilePattern(
+            'phparray',
+            $this->testFilesDir . '/testarray',
+            'translation-%s.php'
+        );
 
-		$this->translator->setLocale('de_DE');
+        $this->translator->setLocale('de_DE');
 
-		$pl0 = $this->translator->translatePlural('Message 12', 'Message 12 Plural', 1);
-		$pl1 = $this->translator->translatePlural('Message 12', 'Message 12 Plural', 2);
-		$pl2 = $this->translator->translatePlural('Message 12', 'Message 12 Plural', 10);
+        $pl0 = $this->translator->translatePlural('Message 12', 'Message 12 Plural', 1);
+        $pl1 = $this->translator->translatePlural('Message 12', 'Message 12 Plural', 2);
+        $pl2 = $this->translator->translatePlural('Message 12', 'Message 12 Plural', 10);
 
-		$this->assertEquals('Message 12', $pl0);
-		$this->assertEquals('Message 12 Plural', $pl1);
-		$this->assertEquals('Message 12 Plural', $pl2);
-	}
+        $this->assertEquals('Message 12', $pl0);
+        $this->assertEquals('Message 12 Plural', $pl1);
+        $this->assertEquals('Message 12 Plural', $pl2);
+    }
 
     public function testTranslateNoPlurals()
     {
@@ -336,20 +336,20 @@ class TranslatorTest extends TestCase
         $this->assertEquals('Message 9', $this->translator->translate('Message 9'));
     }
 
-	public function testTranslateNonExistantTranslation()
-	{
-		$this->translator->addTranslationFilePattern(
-			'phparray',
-			$this->testFilesDir . '/testarray',
-			'translation-%s.php'
-		);
+    public function testTranslateNonExistantTranslation()
+    {
+        $this->translator->addTranslationFilePattern(
+            'phparray',
+            $this->testFilesDir . '/testarray',
+            'translation-%s.php'
+        );
 
-		// Test that a locale without translations does not cause warnings
+        // Test that a locale without translations does not cause warnings
 
-		$this->translator->setLocale('de_DE');
+        $this->translator->setLocale('de_DE');
 
-		$this->assertEquals('Message 13', $this->translator->translate('Message 13'));
-	}
+        $this->assertEquals('Message 13', $this->translator->translate('Message 13'));
+    }
 
     public function testEnableDisableEventManger()
     {

--- a/test/Translator/_files/testarray/translation-de_DE.php
+++ b/test/Translator/_files/testarray/translation-de_DE.php
@@ -17,4 +17,9 @@ return [
         'Nachricht 10 - 0',
         'Nachricht 10 - 1',
     ],
+	'Message 12' => [
+		'',
+		'',
+	],
+	'Message 13' => '',
 ];


### PR DESCRIPTION
If a po-File has the msgid but no translations, `translatePlural()` translates to an empty string.

This change makes it consistent with the behaviour of `translate()` which also returns the source-code version if the message is not translated.

example:
```po
msgid "Total (%1$s dataset)"
msgid_plural "Total (%1$s datasets)"
msgstr[0] ""
msgstr[1] ""
```