### PR TITLE
Fixes DateTime formatter for different timezones

### DIFF
--- a/src/View/Helper/DateFormat.php
+++ b/src/View/Helper/DateFormat.php
@@ -76,7 +76,7 @@ class DateFormat extends AbstractHelper
         }
 
         $timezone    = $this->getTimezone();
-        $formatterId = md5($dateType . "\0" . $timeType . "\0" . $locale ."\0" . $pattern);
+        $formatterId = md5($dateType . "\0" . $timeType . "\0" . $locale . "\0" . $pattern . "\0" . $timezone);
 
         if (! isset($this->formatters[$formatterId])) {
             $this->formatters[$formatterId] = new IntlDateFormatter(

--- a/test/View/Helper/DateFormatTest.php
+++ b/test/View/Helper/DateFormatTest.php
@@ -286,4 +286,19 @@ class DateFormatTest extends TestCase
     {
         return new IntlDateFormatter($locale, $dateType, $timeType, $timezone, null, $pattern);
     }
+
+    public function testDifferentTimezone()
+    {
+        $helper = $this->helper;
+
+        date_default_timezone_set('America/Chicago');
+        $date = new DateTime('2018-01-01');
+
+        self::assertSame('Jan 1, 2018', $helper($date, IntlDateFormatter::MEDIUM));
+
+        date_default_timezone_set('America/New_York');
+        $date = new DateTime('2018-01-01');
+
+        self::assertSame('Jan 1, 2018', $helper($date, IntlDateFormatter::MEDIUM));
+    }
 }


### PR DESCRIPTION
When default timezones changes between formatter calls the new default
timezone should be used.

Internally, for optimisation purposes, formatter was stored in hash array,
but the hash was generated without timezone.

Fixes #98

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
