### PR TITLE
Moved ext-intl to required instead of suggested.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
+        "ext-intl": "Required for most features of Zend\\I18n; not included in all default builds of PHP",
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
@@ -31,7 +32,6 @@
         "zendframework/zend-view": "^2.6.3"
     },
     "suggest": {
-        "ext-intl": "Required for most features of Zend\\I18n; included in default builds of PHP",
         "zendframework/zend-cache": "Zend\\Cache component",
         "zendframework/zend-config": "Zend\\Config component",
         "zendframework/zend-eventmanager": "You should install this package to use the events in the translator",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "ext-intl": "Required for most features of Zend\\I18n; not included in all default builds of PHP",
+        "ext-intl": "*",
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Because the extension is not included in all default builds of PHP, and is required for translate usage.

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - Because the php-intl extension is required for even the most simply use of translate, and not all installs of PHP include it by default. Having it in the suggested area, when most usage requires it, seemed inappropriate.
