### PR TITLE
Adds missing blank line before code example to fix render error

### DIFF
--- a/docs/book/view-helpers.md
+++ b/docs/book/view-helpers.md
@@ -21,6 +21,7 @@ for more information.
 > the IDE can auto-suggest the default view helpers from `zend-view`. Next,
 > chain the `HelperTrait` from `zend-i18n` with a pipe symbol (a.k.a. vertical
 > bar) `|`:
+>
 > ```php
 > /**
 >  * @var Zend\View\Renderer\PhpRenderer|Zend\I18n\View\HelperTrait $this


### PR DESCRIPTION
The code block is not completely replaced by the [script for "fenced code"](https://github.com/zendframework/zf-mkdoc-theme/blob/master/fenced_code.php): https://docs.zendframework.com/zend-i18n/view-helpers/