### PR TITLE
PHP 7.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,15 @@ matrix:
     - php: 7.3
       env:
         - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
+      env:
+        - DEPS=locked
+    - php: 7.4
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
         "zendframework/zend-validator": "^2.6",
         "zendframework/zend-view": "^2.6.3"
     },
+    "conflict": {
+        "phpspec/prophecy": "<1.9.0"
+    },
     "suggest": {
         "zendframework/zend-cache": "Zend\\Cache component",
         "zendframework/zend-config": "Zend\\Config component",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8372864bd80035f9a90e9318be38672",
+    "content-hash": "ae170a8303aedd000edf825b5a484572",
     "packages": [
         {
             "name": "zendframework/zend-stdlib",
@@ -86,16 +86,16 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
                 "shasum": ""
             },
             "require": {
@@ -138,7 +138,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-03-17T17:37:11+00:00"
+            "time": "2019-10-21T16:45:58+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -442,22 +442,22 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.1",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
+                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
-                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
                 "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
@@ -501,7 +501,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-06-13T12:50:23+00:00"
+            "time": "2019-10-03T11:07:50+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1534,16 +1534,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
                 "shasum": ""
             },
             "require": {
@@ -1555,7 +1555,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -1588,7 +1588,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1632,31 +1632,29 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.3 || ^7.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -1678,7 +1676,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2019-08-24T08:43:50+00:00"
+            "time": "2019-11-24T13:36:37+00:00"
         },
         {
             "name": "zendframework/zend-cache",

--- a/test/Translator/TranslatorServiceFactoryTest.php
+++ b/test/Translator/TranslatorServiceFactoryTest.php
@@ -17,40 +17,27 @@ class TranslatorServiceFactoryTest extends TestCase
 {
     public function testCreateServiceWithNoTranslatorKeyDefined()
     {
-        $pluginManagerMock = $this->createMock(LoaderPluginManager::class);
-        $slContents        = [
-            ['config', []],
-            ['TranslatorPluginManager', $pluginManagerMock]
-        ];
+        $pluginManagerMock = $this->prophesize(LoaderPluginManager::class)->reveal();
 
-        $serviceLocator = $this->createMock(ContainerInterface::class);
-        $serviceLocator
-            ->expects($this->once())
-            ->method('has')
-            ->with($this->equalTo('TranslatorPluginManager'))
-            ->willReturn(true);
-        $serviceLocator
-            ->expects($this->exactly(2))
-            ->method('get')
-            ->willReturnMap($slContents);
+        $serviceLocator = $this->prophesize(ContainerInterface::class);
+        $serviceLocator->has('TranslatorPluginManager')->willReturn(true)->shouldBeCalledTimes(1);
+        $serviceLocator->get('TranslatorPluginManager')->willReturn($pluginManagerMock)->shouldBeCalledTimes(1);
+        $serviceLocator->get('config')->willReturn([])->shouldBeCalledTimes(1);
 
         $factory = new TranslatorServiceFactory();
-        $translator = $factory($serviceLocator, Translator::class);
+        $translator = $factory($serviceLocator->reveal(), Translator::class);
         $this->assertInstanceOf(Translator::class, $translator);
         $this->assertSame($pluginManagerMock, $translator->getPluginManager());
     }
 
     public function testCreateServiceWithNoTranslatorPluginManagerDefined()
     {
-        $serviceLocator = $this->createMock(ContainerInterface::class);
-        $serviceLocator
-            ->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('config'))
-            ->willReturn([]);
+        $serviceLocator = $this->prophesize(ContainerInterface::class);
+        $serviceLocator->has('TranslatorPluginManager')->willReturn(false)->shouldBeCalledTimes(1);
+        $serviceLocator->get('config')->willReturn([])->shouldBeCalledTimes(1);
 
         $factory = new TranslatorServiceFactory();
-        $translator = $factory($serviceLocator, Translator::class);
+        $translator = $factory($serviceLocator->reveal(), Translator::class);
         $this->assertInstanceOf(Translator::class, $translator);
     }
 }

--- a/test/View/Helper/TranslatePluralTest.php
+++ b/test/View/Helper/TranslatePluralTest.php
@@ -9,6 +9,7 @@ namespace ZendTest\I18n\View\Helper;
 
 use PHPUnit\Framework\TestCase;
 use Zend\I18n\View\Helper\TranslatePlural as TranslatePluralHelper;
+use Zend\I18n\Translator\Translator;
 
 /**
  * @group      Zend_View
@@ -56,19 +57,12 @@ class TranslatePluralTest extends TestCase
         $numberInput   = 1;
         $expected      = 'translated';
 
-        $translatorMock = $this->createMock('Zend\I18n\Translator\Translator');
-        $translatorMock->expects($this->once())
-                       ->method('translatePlural')
-                       ->with(
-                           $this->equalTo($singularInput),
-                           $this->equalTo($pluralInput),
-                           $this->equalTo($numberInput),
-                           $this->equalTo('default'),
-                           $this->equalTo(null)
-                       )
-                       ->willReturn($expected);
+        $translatorMock = $this->prophesize(Translator::class);
+        $translatorMock->translatePlural($singularInput, $pluralInput, $numberInput, 'default', null)
+            ->willReturn($expected)
+            ->shouldBeCalledTimes(1);
 
-        $this->helper->setTranslator($translatorMock);
+        $this->helper->setTranslator($translatorMock->reveal());
 
         $this->assertEquals($expected, $this->helper->__invoke($singularInput, $pluralInput, $numberInput));
     }
@@ -82,19 +76,12 @@ class TranslatePluralTest extends TestCase
         $textDomain    = 'textDomain';
         $locale        = 'en_US';
 
-        $translatorMock = $this->createMock('Zend\I18n\Translator\Translator');
-        $translatorMock->expects($this->once())
-                       ->method('translatePlural')
-                       ->with(
-                           $this->equalTo($singularInput),
-                           $this->equalTo($pluralInput),
-                           $this->equalTo($numberInput),
-                           $this->equalTo($textDomain),
-                           $this->equalTo($locale)
-                       )
-                       ->willReturn($expected);
+        $translatorMock = $this->prophesize(Translator::class);
+        $translatorMock->translatePlural($singularInput, $pluralInput, $numberInput, $textDomain, $locale)
+            ->willReturn($expected)
+            ->shouldBeCalledTimes(1);
 
-        $this->helper->setTranslator($translatorMock);
+        $this->helper->setTranslator($translatorMock->reveal());
 
         $this->assertEquals($expected, $this->helper->__invoke(
             $singularInput,

--- a/test/View/Helper/TranslateTest.php
+++ b/test/View/Helper/TranslateTest.php
@@ -9,6 +9,7 @@ namespace ZendTest\I18n\View\Helper;
 
 use PHPUnit\Framework\TestCase;
 use Zend\I18n\View\Helper\Translate as TranslateHelper;
+use Zend\I18n\Translator\Translator;
 
 /**
  * @group      Zend_View
@@ -54,13 +55,12 @@ class TranslateTest extends TestCase
         $input    = 'input';
         $expected = 'translated';
 
-        $translatorMock = $this->createMock('Zend\I18n\Translator\Translator');
-        $translatorMock->expects($this->once())
-                       ->method('translate')
-                       ->with($this->equalTo($input), $this->equalTo('default'), $this->equalTo(null))
-                       ->willReturn($expected);
+        $translatorMock = $this->prophesize(Translator::class);
+        $translatorMock->translate($input, 'default', null)
+            ->willReturn($expected)
+            ->shouldBeCalledTimes(1);
 
-        $this->helper->setTranslator($translatorMock);
+        $this->helper->setTranslator($translatorMock->reveal());
 
         $this->assertEquals($expected, $this->helper->__invoke($input));
     }
@@ -72,13 +72,12 @@ class TranslateTest extends TestCase
         $textDomain = 'textDomain';
         $locale     = 'en_US';
 
-        $translatorMock = $this->createMock('Zend\I18n\Translator\Translator');
-        $translatorMock->expects($this->once())
-                       ->method('translate')
-                       ->with($this->equalTo($input), $this->equalTo($textDomain), $this->equalTo($locale))
-                       ->willReturn($expected);
+        $translatorMock = $this->prophesize(Translator::class);
+        $translatorMock->translate($input, $textDomain, $locale)
+            ->willReturn($expected)
+            ->shouldBeCalledTimes(1);
 
-        $this->helper->setTranslator($translatorMock);
+        $this->helper->setTranslator($translatorMock->reveal());
 
         $this->assertEquals($expected, $this->helper->__invoke($input, $textDomain, $locale));
     }


### PR DESCRIPTION
Update Travis CI configuration
Add conflict with Prophecy < 1.9.0
Update tests to use prophecy mocking as not all PHPUnit versions are compatible with PHP 7.4